### PR TITLE
Protein model rewrite

### DIFF
--- a/models/proteinModel.js
+++ b/models/proteinModel.js
@@ -5,6 +5,85 @@ import { getDifferentialAbundanceByAccession } from './searchModel.js';
 
 
 
+/**
+ * Processes experimental data for a single experiment to calculate scores and significance vectors.
+ * 
+ * This function is called from `prepareData` to process each grouped experiment (dpx_comparison)
+ * 
+ * @param {Array<{pos_start: number, pos_end: number, diff: number, adj_pval: number}>} data - Array of experimental data rows.
+ *   - `pos_start`: The starting position of the peptide in the protein sequence.
+ *   - `pos_end`: The ending position of the peptide.
+ *   - `diff`: The differential abundance log2 fold change.
+ *   - `adj_pval`: The adjusted p-value (q-value) for significance.
+ * @param {string} proteinSequence - The full amino acid sequence of the protein.
+ * 
+ * @returns {Array<{index: number, sig: number|null, aminoacid: string, detected: number|null, score: number}>} 
+ *          An array of processed data points representing each position in the sequence up to maxIndex.
+ *          Each element is an object with the following fields:
+ *          - `index`: The zero-based position in the protein sequence.
+ *          - `sig`: The significance value based on log2 fold change if thresholds are met
+ *          - `aminoacid`: The single-letter amino acid code at this position.
+ *          - `detected`: 1 if the position was covered by a peptide but did not meet significance thresholds, otherwise null.
+ *          - `score`: Currently the averaged diff at this position
+ */
+export function processExperimentData(data, proteinSequence) {
+  if (!data || data.length === 0) return [];
+
+  const maxIndex = Math.max(...data.map(row => Math.round(row.pos_end)));
+  
+  // 1. Define arrays for sums and counts
+  const sums = new Array(maxIndex + 1).fill(0);
+  const counts = new Array(maxIndex + 1).fill(0);
+
+  // 2. Accumulate sums and counts
+  data.forEach(row => {
+    // If we ever get fractional indices, it will work wrongly and will not signal the error
+    // Rounding for peace of mind. We mostly expect integer indices.
+    const start = Math.round(row.pos_start);
+    const end = Math.round(row.pos_end);
+
+    // Diff can be negative but for averaging still looks fine.
+    const diff = !isFinite(row.diff) ? 0 : row.diff;
+
+    for (let i = start; i < end; i++) {
+      if (i < sums.length) {
+        sums[i] += diff;
+        counts[i] += 1;
+      }
+    }
+  });
+
+  // 3. Calculate averages where we have observed the values, null otherwise
+  const averages = sums.map((sum, i) => counts[i] > 0 ? sum / counts[i] : null);
+
+  // 4. Find min and max for normalization (ignoring nulls where count was 0)
+  const validAverages = averages.filter(avg => avg !== null);
+  const min = validAverages.length > 0 ? Math.min(...validAverages) : 0;
+  const max = validAverages.length > 0 ? Math.max(...validAverages) : 0;
+
+  // We cannot normalize with all values equal. Returning 0.5. Same if we do not have any valid values.
+  const isDegenerate = min === max;
+
+  // 5. Build the final array with normalized scores, setting sig and detected to 1
+  return averages.map((avg, index) => {
+    let normalizedScore = 0.5;
+    
+    if (avg !== null && !isDegenerate) {
+      normalizedScore = (avg - min) / (max - min);
+    }
+
+    const isCovered = counts[index] > 0;
+
+    return {
+      index,
+      sig: isCovered ? 1 : null,
+      aminoacid: proteinSequence[index] || '',
+      detected: isCovered ? 1 : null,
+      score: normalizedScore
+    };
+  });
+}
+
 export const prepareData = (jsonData, proteinSequence) => {
   /**
    * Prepare data for barcode visualization
@@ -23,44 +102,6 @@ export const prepareData = (jsonData, proteinSequence) => {
    */
 
 
-  // Helper function to process data for a single experiment
-  function processExperimentData(data) {
-    const maxIndex = Math.max(...data.map(row => Math.round(row.pos_end)));
-    const len_vector = new Array(maxIndex + 1).fill(0); // +1 because arrays are 0-indexed
-    const len_vector_detected = new Array(maxIndex + 1).fill(0);
-    const scores = new Array(maxIndex + 1).fill(null);
-
-    const qvalue_cutoff = 0.05;
-    const log2FC_cutoff = 0.2;
-
-    data.forEach(row => {
-      const start = Math.round(row.pos_start);
-      const end = Math.round(row.pos_end);
-      const log2FC = !isFinite(row.diff) ? 0 : row.diff;
-      const qvalue = row.adj_pval;
-      const score = -Math.log10(qvalue) + Math.abs(log2FC);
-
-      for (let i = start; i < end; i++) {
-        if (i < len_vector.length) {
-          scores[i] = score;
-          if (qvalue < qvalue_cutoff && Math.abs(log2FC) > log2FC_cutoff) {
-            len_vector[i] = len_vector[i] !== 0 ? (len_vector[i] + log2FC) / 2 : log2FC;
-          } else {
-            len_vector_detected[i] = 1;
-          }
-        }
-      }
-    });
-
-    return len_vector.map((sig, index) => ({
-      index,
-      sig: isNaN(sig) ? null : sig,
-      aminoacid: proteinSequence[index] || '',
-      detected: len_vector_detected[index] || null,
-      score: scores[index]
-    }));
-  }
-
   // Split data by experimentID
   const experiments = jsonData.reduce((acc, row) => {
     if (!acc[row.dpx_comparison]) {
@@ -72,7 +113,7 @@ export const prepareData = (jsonData, proteinSequence) => {
 
   // Process each experiment's data
   const processedData = Object.keys(experiments).reduce((acc, dpx_comparison) => {
-    acc[dpx_comparison] = processExperimentData(experiments[dpx_comparison]);
+    acc[dpx_comparison] = processExperimentData(experiments[dpx_comparison], proteinSequence);
     return acc;
   }, {});
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "node index.mjs"
+    "start": "node index.mjs",
+    "test": "node --test"
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",

--- a/tests/proteinModel.test.js
+++ b/tests/proteinModel.test.js
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { processExperimentData } from '../models/proteinModel.js';
+
+test('processExperimentData processes overlapping fragments correctly', () => {
+  // Short protein of 4 amino acids: "ABCD" (indices 0, 1, 2, 3)
+  // Two fragments of 3 amino acids each, overlapping in the middle (indices 1 and 2)
+  const data = [
+    { pos_start: 0, pos_end: 3, diff: 1.0, adj_pval: 0.01 }, // covers indices 0, 1, 2
+    { pos_start: 1, pos_end: 4, diff: 3.0, adj_pval: 0.01 }  // covers indices 1, 2, 3
+  ];
+  const sequence = "ABCD";
+
+  const result = processExperimentData(data, sequence);
+
+  // Max pos_end is 4, so result array length will be 5 (indices 0 to 4)
+  assert.strictEqual(result.length, 5, 'Result length should be max pos_end + 1');
+
+  // Index 0: only fragment 1. sum = 1.0, count = 1 -> avg = 1.0
+  // Normalization: min avg = 1.0, max avg = 3.0
+  // Normalized: (1.0 - 1.0) / (3.0 - 1.0) = 0.0
+  assert.strictEqual(result[0].aminoacid, 'A');
+  assert.strictEqual(result[0].detected, 1);
+  assert.strictEqual(result[0].sig, 1);
+  assert.strictEqual(result[0].score, 0.0);
+
+  // Index 1: fragment 1 & 2. sum = 1.0 + 3.0 = 4.0, count = 2 -> avg = 2.0
+  // Normalized: (2.0 - 1.0) / 2.0 = 0.5
+  assert.strictEqual(result[1].aminoacid, 'B');
+  assert.strictEqual(result[1].detected, 1);
+  assert.strictEqual(result[1].sig, 1);
+  assert.strictEqual(result[1].score, 0.5);
+
+  // Index 2: fragment 1 & 2. sum = 1.0 + 3.0 = 4.0, count = 2 -> avg = 2.0
+  // Normalized: (2.0 - 1.0) / 2.0 = 0.5
+  assert.strictEqual(result[2].aminoacid, 'C');
+  assert.strictEqual(result[2].detected, 1);
+  assert.strictEqual(result[2].sig, 1);
+  assert.strictEqual(result[2].score, 0.5);
+
+  // Index 3: only fragment 2. sum = 3.0, count = 1 -> avg = 3.0
+  // Normalized: (3.0 - 1.0) / 2.0 = 1.0
+  assert.strictEqual(result[3].aminoacid, 'D');
+  assert.strictEqual(result[3].detected, 1);
+  assert.strictEqual(result[3].sig, 1);
+  assert.strictEqual(result[3].score, 1.0);
+
+  // Index 4: out of bounds for sequence "ABCD" (empty string), but tracked due to pos_end=4
+  assert.strictEqual(result[4].aminoacid, '');
+  assert.strictEqual(result[4].sig, null);
+  assert.strictEqual(result[4].detected, null);
+  assert.strictEqual(result[4].score, 0.5); // Default score for avg === null
+});
+
+test('processExperimentData handles uncovered positions and degenerate cases', () => {
+  const data = [
+    { pos_start: 1, pos_end: 3, diff: 2.0, adj_pval: 0.05 } // covers indices 1, 2
+  ];
+  const sequence = "ABCD";
+
+  const result = processExperimentData(data, sequence);
+
+  // Index 0: uncovered -> score 0.5, sig/detected null
+  assert.strictEqual(result[0].sig, null);
+  assert.strictEqual(result[0].detected, null);
+  assert.strictEqual(result[0].score, 0.5);
+
+  // Index 1: degenerate (min=max=2) -> score 0.5
+  assert.strictEqual(result[1].sig, 1);
+  assert.strictEqual(result[1].detected, 1);
+  assert.strictEqual(result[1].score, 0.5);
+
+  // Index 2: degenerate -> score 0.5
+  assert.strictEqual(result[2].sig, 1);
+  assert.strictEqual(result[2].detected, 1);
+  assert.strictEqual(result[2].score, 0.5);
+});


### PR DESCRIPTION
Here is the rewrite of the score processing algorithm. It is done in my best understanding on requirements and is currently very simple: score at location is the average of all scores that occur there for different peptides, and this is normalized into 0..1 over all protein sequence before returning. It is way less sophisticated than the previous version.

I myself still have some doubts we maybe need to clarify, most important

#### 1. Ignoring Statistical Significance (`adj_pval`)
the code completely ignores the `adj_pval` (adjusted p-value/q-value) provided in the data. Really we do not need?

#### 2. Min-Max Normalization of Log2 Fold Changes
Log2 fold change is a centered metric where `0` means "no change". A value of `+2` indicates a 4-fold increase, and `-2` indicates a 4-fold decrease. 
- The current code applies a global min-max normalization `(avg - min) / (max - min)` across the entire protein. I am not sure if it is correct to do this for the log scale. Values close to zero would have very large negative logarithms.
 
#### 3. Conflating "Detected" with "Significant"
I am currently unaware how and if I should handle them differently.

